### PR TITLE
test: improve engine rendering tests and add Triton editor coverage

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -50,6 +50,7 @@ import "./galatea.test.js"
 
 // Editor tests
 import "./editor.test.js"
+import "./triton-editor.test.js"
 
 const { failed } = await printResults();
 

--- a/tests/shape.test.js
+++ b/tests/shape.test.js
@@ -1,26 +1,56 @@
-// Visual Testing
-
 import * as npt from "../src/neptune.js";
-import { describe } from "./tester.js";
+import { describe, it, expect } from "./tester.js";
 
+function createMockContext() {
+    const calls = [];
+    return {
+        calls,
+        save: () => calls.push("save"),
+        restore: () => calls.push("restore"),
+        translate: (...args) => calls.push(["translate", ...args]),
+        rotate: (...args) => calls.push(["rotate", ...args]),
+        scale: (...args) => calls.push(["scale", ...args]),
+        beginPath: () => calls.push(["beginPath"]),
+        arc: (...args) => calls.push(["arc", ...args]),
+        rect: (...args) => calls.push(["rect", ...args]),
+        moveTo: (...args) => calls.push(["moveTo", ...args]),
+        lineTo: (...args) => calls.push(["lineTo", ...args]),
+        closePath: () => calls.push(["closePath"]),
+        fill: () => calls.push(["fill"]),
+        stroke: () => calls.push(["stroke"]),
+        set globalCompositeOperation(value) { calls.push(["globalCompositeOperation", value]); },
+        set filter(value) { calls.push(["filter", value]); },
+        set fillStyle(value) { calls.push(["fillStyle", String(value)]); },
+        set strokeStyle(value) { calls.push(["strokeStyle", String(value)]); },
+        set lineWidth(value) { calls.push(["lineWidth", value]); }
+    };
+}
 
-const scene = new npt.Scene("TestScene");
-npt.SceneManager.LoadScene(scene.id);
+describe("Shape", () => {
+    it("deserializes colors and renders polygons", () => {
+        const shape = new npt.Shape();
+        shape.deserialize({
+            geometry: npt.Shape.POLYGON,
+            param: {
+                fill: false,
+                color: { r: 1, g: 2, b: 3, a: 1 },
+                outline: { r: 9, g: 8, b: 7, a: 1 },
+                points: [new npt.Vector2(0, 0), new npt.Vector2(5, 0), new npt.Vector2(5, 5)]
+            }
+        });
 
+        expect(shape.color).toBeInstanceOf(npt.Color);
+        expect(shape.outline).toBeInstanceOf(npt.Color);
+        expect(shape.geometry).toBe(npt.Shape.POLYGON);
 
-const entity = new npt.Entity("TestEntity");
-entity.AddComponent(new npt.Transform(new npt.Vector2(40,40),0,new npt.Vector2(1,1)));
-scene.AddChild(entity);
-const circle = new npt.Shape(npt.Shape.CIRCLE,{fill:true,radius:5});
-const rect = new npt.Shape(npt.Shape.RECTANGLE,{fill:true,width:10,height:10});
-const line = new npt.Shape(npt.Shape.LINE,{fill:true,width:10,height:10,color:npt.Color.white,thickness:5});
-const triangle = new npt.Shape(npt.Shape.TRIANGLE,{fill:true,width:10,height:10,color:npt.Color.white,thickness:1});
-const polygon = new npt.Shape(npt.Shape.POLYGON,{fill:true,color:npt.Color.white,thickness:1,points:[new npt.Vector2(-30,0),new npt.Vector2(10,0),new npt.Vector2(10,30)]});
+        const entity = new npt.Entity("ShapeEntity");
+        entity.AddComponent(new npt.Transform());
+        entity.AddComponent(shape);
 
-entity.AddComponent(polygon);
-// entity.AddComponent(triangle);
-// entity.AddComponent(line);
-// entity.AddComponent(circle);
-// entity.AddComponent(rect);
+        const ctx = createMockContext();
+        shape.draw(ctx);
 
-describe("Shape", () => {});
+        const lineCalls = ctx.calls.filter((c) => Array.isArray(c) && c[0] === "lineTo");
+        expect(lineCalls.length).toBe(2);
+    });
+});

--- a/tests/sprite.test.js
+++ b/tests/sprite.test.js
@@ -1,24 +1,70 @@
 import * as npt from "../src/neptune.js";
-import { describe } from "./tester.js";
+import { describe, it, expect } from "./tester.js";
 
+function createMockContext() {
+    const calls = [];
+    const ctx = {
+        calls,
+        save: () => calls.push("save"),
+        restore: () => calls.push("restore"),
+        translate: (...args) => calls.push(["translate", ...args]),
+        rotate: (...args) => calls.push(["rotate", ...args]),
+        scale: (...args) => calls.push(["scale", ...args]),
+        drawImage: (...args) => calls.push(["drawImage", ...args]),
+        beginPath: () => calls.push(["beginPath"]),
+        arc: (...args) => calls.push(["arc", ...args]),
+        fill: () => calls.push(["fill"]),
+        stroke: () => calls.push(["stroke"]),
+        rect: (...args) => calls.push(["rect", ...args]),
+        moveTo: (...args) => calls.push(["moveTo", ...args]),
+        lineTo: (...args) => calls.push(["lineTo", ...args]),
+        closePath: () => calls.push(["closePath"]),
+        set globalCompositeOperation(value) { calls.push(["globalCompositeOperation", value]); },
+        set filter(value) { calls.push(["filter", value]); }
+    };
+    return ctx;
+}
 
-const sprite = new npt.Sprite("https://source.unsplash.com/random/100x100",20,20);
-const entity = new npt.Entity("TestEntity");
-entity.AddComponent(new npt.Transform(new npt.Vector2(40,40),0,new npt.Vector2(1,1)));
-entity.AddComponent(sprite);
+describe("Sprite", () => {
+    it("stores constructor values and supports sourceRect rendering", () => {
+        const sprite = new npt.Sprite("sprite.png", 2, 3);
+        expect(sprite.path).toBe("sprite.png");
+        expect(sprite.width).toBe(2);
+        expect(sprite.height).toBe(3);
 
+        sprite.deserialize({ sourceRect: { x: 1, y: 2, width: 3, height: 4 } });
+        expect(sprite._properties.sourceRect.width).toBe(3);
 
-const scene = new npt.Scene("TestScene");
-scene.AddChildren(entity);
-npt.SceneManager.LoadScene(scene.id);
+        const entity = new npt.Entity("SpriteEntity");
+        entity.AddComponent(new npt.Transform(new npt.Vector2(1, 1), 0, new npt.Vector2(1, 1)));
+        entity.AddComponent(sprite);
 
+        const ctx = createMockContext();
+        sprite.draw(ctx);
 
-const scene2 = new npt.Scene("TestScene2");
-const entity2 = new npt.Entity("TestEntity2");
-entity2.AddComponent(new npt.Transform(new npt.Vector2(40,40),0,new npt.Vector2(1,1)));
-entity2.AddComponent(new npt.Sprite("https://source.unsplash.com/random/100x100",20,20));
-scene2.AddChildren(entity2);
-npt.SceneManager.LoadScene(scene2.id);
+        const drawCall = ctx.calls.find((c) => Array.isArray(c) && c[0] === "drawImage");
+        expect(drawCall.length).toBe(10);
+    });
 
+    it("draws children renderables", () => {
+        const parent = new npt.Entity("Parent");
+        const child = new npt.Entity("Child");
 
-describe("Sprite", () => {});
+        const parentSprite = new npt.Sprite("parent.png", 1, 1);
+        const childShape = new npt.Shape(npt.Shape.CIRCLE, { radius: 1 });
+
+        parent.AddComponent(new npt.Transform());
+        child.AddComponent(new npt.Transform());
+        parent.AddComponent(parentSprite);
+        child.AddComponent(childShape);
+        parent.AddChild(child);
+
+        const ctx = createMockContext();
+        parentSprite.draw(ctx);
+
+        const drawImageCalls = ctx.calls.filter((c) => Array.isArray(c) && c[0] === "drawImage");
+        const arcCalls = ctx.calls.filter((c) => Array.isArray(c) && c[0] === "arc");
+        expect(drawImageCalls.length).toBe(1);
+        expect(arcCalls.length).toBe(1);
+    });
+});

--- a/tests/triton-editor.test.js
+++ b/tests/triton-editor.test.js
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+import { describe, it, expect } from "./tester.js";
+
+const tritonRoot = path.resolve("triton");
+
+describe("Triton Editor", () => {
+    it("contains required front-end entry points", () => {
+        const appTsx = path.join(tritonRoot, "src", "App.tsx");
+        const mainTsx = path.join(tritonRoot, "src", "main.tsx");
+
+        expect(fs.existsSync(appTsx)).toBe(true);
+        expect(fs.existsSync(mainTsx)).toBe(true);
+    });
+
+    it("registers core tauri commands for file-system operations", () => {
+        const rustLib = fs.readFileSync(path.join(tritonRoot, "src-tauri", "src", "lib.rs"), "utf8");
+        const requiredCommands = [
+            "initialize_project",
+            "scan_project",
+            "create_directory",
+            "create_asset",
+            "delete_fs_node",
+            "rename_fs_node",
+            "duplicate_fs_node",
+            "read_file",
+            "write_file"
+        ];
+
+        for (const command of requiredCommands) {
+            expect(rustLib.includes(command)).toBe(true);
+        }
+    });
+});

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,49 +1,59 @@
 import * as npt from "../src/neptune.js";
-import { describe } from "./tester.js";
+import { describe, it, expect } from "./tester.js";
 
-
-class TestBehaviour extends npt.Behaviour {
-    constructor() {
-        super();
-        this.Init = () => {
-            console.log("Init");
-        }
-
-        this.Update = () => {
-            console.log("Update");
-        }
-    }
+function createMockContext() {
+    const calls = [];
+    return {
+        calls,
+        save: () => calls.push("save"),
+        restore: () => calls.push("restore"),
+        translate: (...args) => calls.push(["translate", ...args]),
+        rotate: (...args) => calls.push(["rotate", ...args]),
+        drawImage: (...args) => calls.push(["drawImage", ...args]),
+        fillRect: (...args) => calls.push(["fillRect", ...args]),
+        set globalCompositeOperation(value) { calls.push(["globalCompositeOperation", value]); },
+        set filter(value) { calls.push(["filter", value]); },
+        set fillStyle(value) { calls.push(["fillStyle", String(value)]); }
+    };
 }
 
-const entity = new npt.Entity("TestEntity");
-const behaviour = new   TestBehaviour();
-entity.AddComponent(behaviour);
+describe("UI", () => {
+    it("fills parent and applies margins to child layout", () => {
+        const panel = new npt.Entity("Panel");
+        panel.AddComponent(new npt.UI.UITransform(0, 0, 2, 2, 0));
+        panel.AddComponent(new npt.UI.Panel());
+        panel.AddComponent(new npt.UI.MarginContainer(0.1, 0.1, 0.2, 0.2));
 
-const scene = new npt.Scene("TestScene");
-scene.AddChild(entity);
+        const child = new npt.Entity("Child");
+        child.AddComponent(new npt.UI.UITransform(0, 0, 0.5, 0.5, 0));
+        child.AddComponent(new npt.UI.UISprite("child.png"));
+        panel.AddChild(child);
 
-const canvas = new npt.Entity("Button");
-scene.AddChild(canvas);
-canvas.AddComponent(new npt.UI.UITransform(10, 10, 200, 200, 0)); // Set width and height
-canvas.AddComponent(new npt.UI.Panel());
-canvas.AddComponent(new npt.UI.MarginContainer(4, 5, 2, 3)); // Adjust the spacing as needed
+        panel.GetComponent(npt.UI.UITransform).Fill("both", 0.1, 0.1);
+        panel.GetComponent(npt.UI.MarginContainer).Update();
 
-const sprite = new npt.Entity("Sprite");
-sprite.AddComponent(new npt.UI.UITransform(0, 0, 1, 1, 0));
-sprite.AddComponent(new npt.UI.UISprite("https://st.depositphotos.com/1008768/3573/i/450/depositphotos_35732355-stock-photo-example-button.jpg"));
-sprite.AddComponent(new npt.Behaviour("Sprite", () => {
-    sprite.GetComponent(npt.UI.UISprite).filter.Add(npt.Filter.TYPE.BLUR, "3px");
-    sprite.GetComponent(npt.UI.UISprite).blendMode = npt.Renderable.BLEND_MODE.MULTIPLY;
-}));
+        const childTransform = child.GetComponent(npt.UI.UITransform);
+        expect(childTransform.y).toBeGreaterThan(0);
+        expect(childTransform.height).toBeGreaterThan(0);
+    });
 
+    it("renders panel and sprite", () => {
+        const panelEntity = new npt.Entity("PanelRender");
+        panelEntity.AddComponent(new npt.UI.UITransform(1, 2, 3, 4, 0));
 
-canvas.AddChildren(sprite); // Add sprites as children before Update
+        const panel = new npt.UI.Panel(npt.Color.white);
+        const sprite = new npt.UI.UISprite("image.png");
+        panelEntity.AddComponent(panel);
+        panelEntity.AddComponent(sprite);
 
-canvas.AddComponent(new npt.Behaviour("Canvas", () => {
-    canvas.GetComponent(npt.UI.UITransform).Fill("both", 10, 10);
-    canvas.GetComponent(npt.UI.MarginContainer).Update();
-}));
+        const ctx = createMockContext();
+        panel.draw(ctx);
+        sprite.draw(ctx);
 
-npt.SceneManager.LoadScene(scene.id);
+        const fillRectCalls = ctx.calls.filter((c) => Array.isArray(c) && c[0] === "fillRect");
+        const drawImageCalls = ctx.calls.filter((c) => Array.isArray(c) && c[0] === "drawImage");
 
-describe("UI", () => { });
+        expect(fillRectCalls.length).toBe(1);
+        expect(drawImageCalls.length).toBe(1);
+    });
+});


### PR DESCRIPTION
### Motivation
- Convert visual / no-op rendering tests into deterministic unit tests so rendering and UI logic are validated by assertions instead of manual inspection.
- Add lightweight Triton editor coverage to catch regressions in editor wiring (front-end entry points and Tauri command registration) without running the full Tauri app.
- Ensure the test suite exercises more of the engine surface to increase actionable automated coverage for future development.

### Description
- Reworked rendering tests: replaced visual smoke tests with assertion-based tests for `Sprite` (`tests/sprite.test.js`) including constructor/property checks, `sourceRect` handling and child renderable propagation using a mocked canvas context.
- Rewrote `Shape` tests (`tests/shape.test.js`) to validate `deserialize()` color conversion and polygon drawing by inspecting mocked draw calls.
- Replaced the UI smoke test with deterministic layout and render assertions in `tests/ui.test.js` (tests `UITransform.Fill`, `MarginContainer.Update`, `Panel` and `UISprite` rendering via mocked context).
- Added `tests/triton-editor.test.js` to verify presence of front-end entry files (`src/App.tsx`, `src/main.tsx`) and that the Rust `src-tauri/src/lib.rs` registers expected filesystem commands.

### Testing
- Ran the full JavaScript test suite with `npm test`, which completed successfully with `267 passed, 0 failed` (all modified tests included).
- Attempted to build/install Triton dependencies (`cd triton && npm install` / `cd triton && npm run build`) but the environment blocked registry access (HTTP 403), so a full frontend build could not be performed here.
- Attempted to run Rust tests in `triton/src-tauri` (`cargo test`) but network access to crates.io was blocked (download/index failures), so Rust-side execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59ea179dc8332b82ee25b3398bc78)