### PR TITLE
Fix UI rotation handling (use DEG_TO_RAD) and add rotation tests

### DIFF
--- a/src/ui/panel.js
+++ b/src/ui/panel.js
@@ -46,11 +46,14 @@ export class Panel extends Renderable {
         let height = transform.height * Maths.METER_TO_PIXEL;
 
         ctx.save();
-        ctx.rotate(transform.rotation);
+        ctx.translate(x, y);
+        ctx.translate(width / 2, height / 2);
+        ctx.rotate(transform.rotation * Maths.DEG_TO_RAD);
         ctx.globalCompositeOperation = this.blendMode;
         ctx.filter = this.filter;
         ctx.fillStyle = this._properties.color;
-        ctx.fillRect(x, y, width, height);
+        ctx.translate(-width / 2, -height / 2);
+        ctx.fillRect(0, 0, width, height);
 
         let children = this.entity.GetComponentsInChildren(Renderable);
         for (let i = 0; i < children.length; i++) {

--- a/src/ui/sprite.js
+++ b/src/ui/sprite.js
@@ -55,7 +55,7 @@ export class Sprite extends Renderable {
         ctx.save();
         ctx.translate(x, y);
         ctx.translate(width / 2, height / 2);
-        ctx.rotate(this.#transform.rotation * Math.PI / 180);
+        ctx.rotate(this.#transform.rotation * Maths.DEG_TO_RAD);
         ctx.globalCompositeOperation = this.blendMode;
         ctx.filter = this.filter;
         ctx.translate(-width / 2, -height / 2);

--- a/src/ui/text.js
+++ b/src/ui/text.js
@@ -94,9 +94,11 @@ export class Text extends Renderable {
             this.#transform = this.entity.GetComponent(Transform);
 
         ctx.save();
-        ctx.translate(this.#transform.x * Maths.METER_TO_PIXEL, this.#transform.y * Maths.METER_TO_PIXEL);
-        
-        ctx.rotate(this.#transform.rotate);
+        ctx.translate(
+            this.#transform.x * Maths.METER_TO_PIXEL,
+            this.#transform.y * Maths.METER_TO_PIXEL
+        );
+        ctx.rotate(this.#transform.rotation * Maths.DEG_TO_RAD);
         ctx.scale(Maths.METER_TO_PIXEL, Maths.METER_TO_PIXEL);
 
         ctx.font = this.font.toString();

--- a/tests/ui-rotation.test.js
+++ b/tests/ui-rotation.test.js
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { Entity } from "../src/basic/entity.js";
+import { Transform as UITransform } from "../src/ui/uitransform.js";
+import { Panel } from "../src/ui/panel.js";
+import { Sprite as UISprite } from "../src/ui/sprite.js";
+import { Text } from "../src/ui/text.js";
+import { Maths } from "../src/maths/math.js";
+
+class MockImage {
+    constructor() {
+        this.src = "";
+    }
+}
+
+globalThis.Image = MockImage;
+
+function createMockContext() {
+    const calls = [];
+    const ctx = {
+        calls,
+        save: () => calls.push(["save"]),
+        restore: () => calls.push(["restore"]),
+        translate: (...args) => calls.push(["translate", ...args]),
+        rotate: (...args) => calls.push(["rotate", ...args]),
+        scale: (...args) => calls.push(["scale", ...args]),
+        fillRect: (...args) => calls.push(["fillRect", ...args]),
+        drawImage: (...args) => calls.push(["drawImage", ...args]),
+        fillText: (...args) => calls.push(["fillText", ...args]),
+    };
+
+    return ctx;
+}
+
+function createEntityWith(component, rotation = 90) {
+    const entity = new Entity("Rotated UI");
+    entity.AddComponent(new UITransform(1, 2, 3, 4, rotation));
+    entity.AddComponent(component);
+    return entity;
+}
+
+function getRotateCall(ctx) {
+    return ctx.calls.find(([method]) => method === "rotate");
+}
+
+{
+    const panel = new Panel();
+    createEntityWith(panel);
+    const ctx = createMockContext();
+
+    panel.draw(ctx);
+
+    assert.deepEqual(ctx.calls.slice(0, 4), [
+        ["save"],
+        ["translate", 20, 40],
+        ["translate", 30, 40],
+        ["rotate", 90 * Maths.DEG_TO_RAD],
+    ]);
+    assert.deepEqual(ctx.calls.find(([method]) => method === "fillRect"), ["fillRect", 0, 0, 60, 80]);
+}
+
+{
+    const sprite = new UISprite("sprite.png");
+    createEntityWith(sprite);
+    const ctx = createMockContext();
+
+    sprite.draw(ctx);
+
+    assert.equal(getRotateCall(ctx)[1], 90 * Maths.DEG_TO_RAD);
+}
+
+{
+    const text = new Text("Rotated");
+    createEntityWith(text);
+    const ctx = createMockContext();
+
+    text.draw(ctx);
+
+    assert.equal(getRotateCall(ctx)[1], 90 * Maths.DEG_TO_RAD);
+}


### PR DESCRIPTION
### Motivation

- Rotate and draw operations in UI components were inconsistent and treated rotation as radians in some places while rotation values are stored in degrees, causing incorrect rendering and transform origin issues.

### Description

- Updated `Panel` to translate to the entity position, move to the center, rotate using `Maths.DEG_TO_RAD`, then translate back before drawing the rectangle so the panel rotates around its center using `DEG_TO_RAD` for conversion. 
- Updated `Sprite` to use `Maths.DEG_TO_RAD` instead of `Math.PI / 180` for rotation conversion and applied the same translate/rotate/translate pattern. 
- Fixed `Text` to reference `this.#transform.rotation` and convert with `Maths.DEG_TO_RAD`, and normalized the `translate` formatting and `scale` usage. 
- Added a unit test file `tests/ui-rotation.test.js` that mocks `Image` and a 2D canvas context to assert the correct translate/rotate sequence and rotation values for `Panel`, `Sprite`, and `Text`.

### Testing

- Added and ran the unit test `tests/ui-rotation.test.js` which mocks the rendering context and checks rotation math; all assertions passed. 
- No existing tests were modified and the new test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a29e3665083329c315b3d77f69bc3)